### PR TITLE
dotenv support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /files
+.env

--- a/.template.env
+++ b/.template.env
@@ -1,0 +1,14 @@
+# ** Required **
+DATABASE_URL=postgres://user:pass@localhost:5432/dbname
+HOST_URL_ACTIVITYPUB=http://localhost:3333/apub
+HOST_URL_API=http://localhost:3333/api
+
+# ** Configs **
+# APUB_PROXY_REWRITES=true
+# ALLOW_FORWARDED=true
+# BACKEND_HOST=http://localhost:3333
+# MEDIA_LOCATION=./media
+
+# ** Email **
+# SMTP_URL=smtps://username:password@smtp.example.com
+# SMTP_FROM=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1748,7 @@ dependencies = [
  "config 0.11.0",
  "date_duration",
  "deadpool-postgres",
+ "dotenvy",
  "either",
  "env_logger",
  "fast_chemail",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ sha2 = "0.10.2"
 rusoto_s3 = "0.48.0"
 rusoto_core = "0.48.0"
 rusoto_credential = "0.48.0"
+dotenvy = "0.15.7"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1159,6 +1159,7 @@ impl MediaStorage {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
+    let _ = dotenvy::dotenv();
 
     let matches = clap::Command::new("lotide")
         .arg(


### PR DESCRIPTION
Uses [`dotenvy`](https://crates.io/crates/dotenvy) to add `.env` file support. This can make configuring a lotide instance much easier.